### PR TITLE
Fix to work with current master (0.3.3-SNAPSHOT)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='hawkular-client-python',
-      version='0.3.2',
+      version='0.3.3',
       description='Python client to communicate with Hawkular over HTTP',
       author='Michael Burman',
       author_email='miburman@redhat.com',


### PR DESCRIPTION
- create_metric takes MetricType as input while put does not anymore
- MetricType.Numeric -> MetricType.Gauge
- allow pushing multiple metric types with one method (put)
- create_metric_definition returns False/True depending on if the creation succeeded (False on duplicate) -> matching the Golang client.
