### PR TITLE
Add an insecure option for testing hawkular using uncertified ssl connection

### DIFF
--- a/hawkular/metrics.py
+++ b/hawkular/metrics.py
@@ -20,6 +20,7 @@ import codecs
 import time
 import collections
 import base64
+import ssl
 
 try:
     import simplejson as json
@@ -87,6 +88,7 @@ class HawkularMetricsClient:
                  path='hawkular/metrics',
                  scheme='http',
                  cafile=None,
+                 context=None,
                  token=None,
                  username=None,
                  password=None):
@@ -109,6 +111,7 @@ class HawkularMetricsClient:
         self.path = path
         self.cafile = cafile
         self.scheme = scheme
+        self.context = context
         self.token = token
         self.username = username
         self.password = password
@@ -177,7 +180,7 @@ class HawkularMetricsClient:
                     req.data = data.encode('utf-8')
 
             req.get_method = lambda: method
-            res = urlopen(req)
+            res = urlopen(req, context = self.context)
             if method == 'GET':
                 if res.getcode() == 200:
                     data = json.load(reader(res))


### PR DESCRIPTION
**Description**
When using hawkular python client using my python2 and urllib2 I was unable to connect to
the hawkular server because it was insecure. This PR adds the option to connect to an insecure server using ssl for development and testing.

**Example**
Without `context`:

```
client = HawkularMetricsClient(host='yzamir-centos7-1.eng.lab.tlv.redhat.com', port=443, scheme='https', token='...', tenant_id='_system')
>>> client.query_tenants()
 ... <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)>
```

With `context = ssl._create_unverified_context()`:

```
client = HawkularMetricsClient(host='yzamir-centos7-1.eng.lab.tlv.redhat.com', port=443, scheme='https', token='...', tenant_id='_system', context=ssl._create_unverified_context())
>>> client.query_tenants()
[{u'id': u'default'}, {u'id': u'openshift-infra'}, {u'id': u'_system'}]
```
