### PR TITLE
Add an http 1.1 Host header

### DIFF
--- a/hawkular/metrics.py
+++ b/hawkular/metrics.py
@@ -161,6 +161,7 @@ class HawkularMetricsClient:
             req = Request(url=url)
             req.add_header('Content-Type', 'application/json')
             req.add_header('Hawkular-Tenant', self.tenant_id)
+            req.add_header('Host', self.host)
 
             if self.token is not None:
                 req.add_header('Authorization', 'Bearer {0}'.format(self.token))


### PR DESCRIPTION
In openshift-origin the proxy is set to use the `Host` http header. If this header is missing, strange routing errors occur. I think that adding `self.host` to this header is safe, in the context of hawkular client.
