### PR TITLE
Adding support for metrics strings

### DIFF
--- a/hawkular/metrics.py
+++ b/hawkular/metrics.py
@@ -41,6 +41,7 @@ class MetricType:
     Gauge = 'gauges'
     Availability = 'availability'
     Counter = 'counters'
+    String = 'strings'
     Rate = 'rate'
     _Metrics = 'metrics'
 
@@ -50,6 +51,8 @@ class MetricType:
             return 'gauge'
         elif metric_type is MetricType.Counter:
             return 'counter'
+        elif metric_type is MetricType.String:
+            return 'string'
         else:
             return 'availability'
 

--- a/hawkular/metrics_test.py
+++ b/hawkular/metrics_test.py
@@ -174,6 +174,11 @@ class MetricsTestCase(TestMetricFunctionsBase):
         down = self.client.query_metric(MetricType.Availability, 'test.avail.2')
         self.assertEqual(down[0]['value'], Availability.Down)
 
+    def test_add_string_single(self):
+        self.client.push(MetricType.String, 'test.string.1', "foo")
+        data = self.client.query_metric(MetricType.String, 'test.string.1')
+        self.assertEqual(data, 'foo')
+        
     def test_add_gauge_multi_datapoint(self):
         metric_1v = create_datapoint(float(1.45))
         metric_2v = create_datapoint(float(2.00), (time_millis() - 2000))


### PR DESCRIPTION
Hawkular supports strings values in metrics, this pr adds it to the client.
issue: https://github.com/hawkular/hawkular-client-python/issues/14
