### PR TITLE
Add support for group trigger deletion in hawkular alerts

### DIFF
--- a/hawkular/alerts.py
+++ b/hawkular/alerts.py
@@ -155,6 +155,16 @@ class HawkularAlertsClient(HawkularBaseClient):
         data = self._serialize_object(trigger)
         return Trigger(self._post(self._service_url(['triggers', 'groups']), data))
 
+    def delete_group_trigger(self, group_id, keep_non_orphans=False, keep_orphans=False):
+         """
+         Delete a group trigger
+         :param group_id: ID of the group trigger to delete
+         :param keep_non_orphans: if True converts the non-orphan member triggers to standard triggers
+         :param keep_orphans: if True converts the orphan member triggers to standard triggers
+         """
+         params = {'keepNonOrphans': str(keep_non_orphans).lower(), 'keepOrphans': str(keep_orphans).lower()}
+         self._delete(self._service_url(['triggers', 'groups', group_id], params=params))
+
     def create_group_member(self, member):
         data = self._serialize_object(member)
         return Trigger(self._post(self._service_url(['triggers', 'groups', 'members']), data))

--- a/hawkular/client.py
+++ b/hawkular/client.py
@@ -165,7 +165,7 @@ class HawkularBaseClient:
     def tenant(self, tenant_id):
         self.tenant_id = tenant_id
 
-    def _http(self, url, method, data=None, decoder=None):
+    def _http(self, url, method, data=None, decoder=None, parse_json=True):
         res = None
         req = Request(url=url)
         req.add_header('Content-Type', 'application/json')
@@ -193,10 +193,13 @@ class HawkularBaseClient:
             req.get_method = lambda: method
             res = urlopen(req, context=self.context)
 
-            if res.getcode() == 200:
-                data = json.load(reader(res), cls=decoder)
-            elif res.getcode() == 204:
-                data = {}
+            if parse_json:
+                if res.getcode() == 200:
+                    data = json.load(reader(res), cls=decoder)
+                elif res.getcode() == 204:
+                    data = {}
+            else:
+                data = reader(res).read()
 
             return data
 
@@ -211,7 +214,7 @@ class HawkularBaseClient:
         return self._http(url, 'PUT', data)
 
     def _delete(self, url):
-        return self._http(url, 'DELETE')
+        return self._http(url, 'DELETE', parse_json=False)
 
     def _post(self, url, data):
         return self._http(url, 'POST', data)


### PR DESCRIPTION
Adding `delete_group_trigger` method in hawkular alerts and `test_delete_group_trigger` to alerts tests.

Since the `DELETE` action returns only a response code, without body, I added `parse_json` flag to `_http` method in `hawkular/client.py`. Without this addition an error is raised when trying to load
the json with no content. 
I'm setting it to `True` by default, while sending it with `False` from the `_delete` method.
This Issue was solved in `hawkular/metrics.py` by checking that the method is `GET`, a wrong solution IMHO cause `POST` and `PUT` methods also return body.