### PR TITLE
Add support for update group trigger definition in Hawkular alerts

### DIFF
--- a/hawkular/alerts.py
+++ b/hawkular/alerts.py
@@ -155,6 +155,14 @@ class HawkularAlertsClient(HawkularBaseClient):
         data = self._serialize_object(trigger)
         return Trigger(self._post(self._service_url(['triggers', 'groups']), data))
 
+    def update_group_trigger(self, group_id, trigger):
+        """
+        :param group_id: group trigger id to be updated
+        :param trigger: Trigger object, the group trigger to be updated
+        """
+        data = self._serialize_object(trigger)
+        self._put(self._service_url(['triggers', 'groups', group_id]), data, parse_json=False)
+
     def create_group_member(self, member):
         data = self._serialize_object(member)
         return Trigger(self._post(self._service_url(['triggers', 'groups', 'members']), data))

--- a/hawkular/client.py
+++ b/hawkular/client.py
@@ -165,7 +165,7 @@ class HawkularBaseClient:
     def tenant(self, tenant_id):
         self.tenant_id = tenant_id
 
-    def _http(self, url, method, data=None, decoder=None):
+    def _http(self, url, method, data=None, decoder=None, parse_json=True):
         res = None
         req = Request(url=url)
         req.add_header('Content-Type', 'application/json')
@@ -192,12 +192,13 @@ class HawkularBaseClient:
         try:
             req.get_method = lambda: method
             res = urlopen(req, context=self.context)
-
-            if res.getcode() == 200:
-                data = json.load(reader(res), cls=decoder)
-            elif res.getcode() == 204:
-                data = {}
-
+            if parse_json:
+                if res.getcode() == 200:
+                    data = json.load(reader(res), cls=decoder)
+                elif res.getcode() == 204:
+                    data = {}
+            else:
+                data = reader(res).read()
             return data
 
         except Exception as e:
@@ -207,8 +208,8 @@ class HawkularBaseClient:
             if res:
                 res.close()
 
-    def _put(self, url, data):
-        return self._http(url, 'PUT', data)
+    def _put(self, url, data, parse_json=True):
+        return self._http(url, 'PUT', data, parse_json=parse_json)
 
     def _delete(self, url):
         return self._http(url, 'DELETE')

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -158,3 +158,12 @@ class AlertsTestCase(TestAlertsFunctionsBase):
         self.assertEqual(len(gcc), 1)
         t_m1c = self.client.create_group_member(m1)
         self.assertEqual(t_m1c.type, TriggerType.MEMBER)
+
+        # Update group trigger
+        t.enabled = True
+        t.severity = Severity.MEDIUM
+
+        self.client.update_group_trigger(t.id, t)
+        gt = self.client.get_trigger(t.id)
+        self.assertEqual(gt.enabled, True)
+        self.assertEqual(gt.severity, Severity.MEDIUM)


### PR DESCRIPTION
Added a test to `test_create_groups`.

Also, now handles JSON decode errors when the request has no response body (only status code).