### PR TITLE
bytes-compatibility

### DIFF
--- a/hawkular/client.py
+++ b/hawkular/client.py
@@ -209,7 +209,7 @@ class HawkularBaseClient:
         if self.token is not None:
             req.add_header('Authorization', 'Bearer {0}'.format(self.token))
         elif self.username is not None:
-            b64 = base64.b64encode(bytes(self.username + ':' + self.password, encoding='utf-8'))
+            b64 = base64.b64encode((self.username + ':' + self.password).encode('utf-8'))
             req.add_header('Authorization',
                            'Basic {0}'.format(b64))
 


### PR DESCRIPTION
The byte function used in this file is different between python 3 and 2
`str.encode()` works in 3 and 2