### PR TITLE
Fix default port in the client constructor docstring

### DIFF
--- a/hawkular/client.py
+++ b/hawkular/client.py
@@ -150,7 +150,7 @@ class HawkularBaseClient:
         A new instance of HawkularMetricsClient is created with the following defaults:
 
         host = localhost
-        port = 8081
+        port = 8080
         path = hawkular-metrics
         scheme = http
         cafile = None


### PR DESCRIPTION
8081 -> 8080, as the code clearly shows.