### PR TITLE
Remove reason concatenation on Exceptions that doesn't have reason at…

### DIFF
--- a/hawkular/client.py
+++ b/hawkular/client.py
@@ -289,12 +289,12 @@ class HawkularBaseClient(object):
         elif isinstance(e, KeyError):
             # Cast to HawkularMetricsStatusError
             ee = HawkularStatusError(e)
-            ee.msg = "Error, unable to get implementation version for metrics: " + str(e.reason)
+            ee.msg = "Error, unable to get implementation version for metrics: "
             raise ee
         elif isinstance(e, ValueError):
             # Cast to HawkularMetricsStatusError
             ee = HawkularStatusError(e)
-            ee.msg = "Error, unable to determine implementation version for metrics: " + str(e.reason)
+            ee.msg = "Error, unable to determine implementation version for metrics: "
             raise ee
         else:
             raise e


### PR DESCRIPTION
…tribute.

Only the exception `URLError` has an attribute `reason`, so for the other cases if the error happens it throws an no attribute error on console instead of the correct exception because if this.

This PR fixes that, it's a small issue, not a big deal.